### PR TITLE
Add static index page and Astro integration prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ If you run into any issues running Anubis, please [open an issue](https://github
 
 For live chat, please join the [Patreon](https://patreon.com/cadey) and ask in the Patron discord in the channel `#anubis`.
 
+## Static Site Integration
+
+Anubis can stand in front of any static site generator. After building your
+site, point Anubis at the directory of generated files and let it proxy
+requests to them while serving its own assets from
+`/.within.website/x/cmd/anubis/static/`.
+
+> **AI prompt:**
+> "I have an Astro static site and want to protect it with Anubis. Explain how
+> to build the Astro site, start Anubis in front of the `dist` directory, and
+> configure my web server so that Anubis serves its static assets and proxies
+> other requests to the site."
+
 ## Star History
 
 <a href="https://www.star-history.com/#TecharoHQ/anubis&Date">

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Anubis Static Site</title>
+    <link rel="stylesheet" href="/.within.website/x/xess/xess.css"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  </head>
+  <body id="top">
+    <main>
+      <h1>Anubis Static Site</h1>
+      <p>This page is served from Anubis's embedded static assets.</p>
+      <img height="128" src="/.within.website/x/cmd/anubis/static/img/happy.webp" alt="Happy Anubis"/>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `index.html` served from embedded static assets
- document how to use Anubis with Astro static sites and include an AI prompt in README

## Testing
- `go test ./...` *(fails: could not download Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b232230a448332a4687c94b196a78c